### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/wcwidth.cabal
+++ b/wcwidth.cabal
@@ -13,7 +13,7 @@ description                   :
   to Haskell code that assigns widths to the Char type.
 
 
-cabal-version                 : >= 1.6.0
+cabal-version                 : >= 1.8
 build-type                    : Simple
 extra-source-files            : CompileRanges.hs
 


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: wcwidth.cabal:47:45: version operators used. To use version operators
the package needs to specify at least 'cabal-version: >= 1.8'.
```