### PR TITLE
Add Github Action CI build Matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+on: [push]
+name: build
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        ghc: ['9.0.2']
+        cabal: ['3.6']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    name: Haskell GHC ${{ matrix.ghc }} sample
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Haskell
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+      - run: |
+        cabal test --system-ghc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
         ghc: ['9.0.2']
         cabal: ['3.6']
         os: [ubuntu-latest, macOS-latest, windows-latest]
-    name: Haskell GHC ${{ matrix.ghc }} sample
+    name: Haskell GHC ${{ matrix.ghc }} ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Haskell
@@ -17,4 +17,4 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
       - run: |
-        cabal test --system-ghc
+          cabal test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work
 .vscode
+dist-newstyle/


### PR DESCRIPTION
In view of fixing #7 it would be helpful to have some CI running.
This PR adds a simple Github Action CI with a buildmatrix for Windows, MacOS and Ubuntu.